### PR TITLE
Get maintenance banner into production branch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,5 +3,3 @@ author: CMEC
 markdown: kramdown
 rouge: true
 theme: jekyll-theme-cayman
-gems:
-- jekyll-seo-tag

--- a/_config.yml
+++ b/_config.yml
@@ -3,3 +3,5 @@ author: CMEC
 markdown: kramdown
 rouge: true
 theme: jekyll-theme-cayman
+gems:
+- jekyll-seo-tag

--- a/_includes/maintenance_banner.html
+++ b/_includes/maintenance_banner.html
@@ -1,0 +1,6 @@
+<div class="container">
+    <b>
+        Due to scheduled maintenance, a website outage will occur from noon Friday 4th October 2019
+        through early morning Monday 7th October 2019.  Apologies in advance for any inconvenience.
+    </b>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
   </head>
   <body>
+    {% include maintenance_banner.html %}
     {% include nav.html %}
 
     <section class="page-header">


### PR DESCRIPTION
I forgot that the site was serving the `production` branch of this repo.