### PR TITLE
change "name" to "title" in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: Coordinated Model Evaluation Capabilities
+title: Coordinated Model Evaluation Capabilities
 author: CMEC
 markdown: kramdown
 rouge: true


### PR DESCRIPTION
The Jekyll build for cmec.llnl.gov is generating the following warning.
```
GitHub Metadata: site.name is set in _config.yml, but many plugins and themes expect site.title to be used instead. To avoid potential inconsistency, Jekyll GitHub Metadata will not set site.title to the repository's name.
```
This PR will change `name` to `title` in _config.yml.