### PR TITLE
Add table of CMEC metrics package contents

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -26,7 +26,7 @@
                         <a class="dropdown-item" href="{{site.baseurl}}/ilamb.html">ILAMB</a>
                         <a class="dropdown-item" href="{{site.baseurl}}/iomb.html">IOMB</a>
                         <a class="dropdown-item" href="{{site.baseurl}}/teca.html">TECA</a>
-                        <a class="dropdown-item" href="{{site.baseurl}}/metrics.html">Metrics list</a>
+                        <a class="dropdown-item" href="{{site.baseurl}}/metrics.html">Capabilities table</a>
                     </div>
                 </li>
                 <li class="nav-item{% if page.url == '/results/' %} active {% endif %}">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -26,6 +26,7 @@
                         <a class="dropdown-item" href="{{site.baseurl}}/ilamb.html">ILAMB</a>
                         <a class="dropdown-item" href="{{site.baseurl}}/iomb.html">IOMB</a>
                         <a class="dropdown-item" href="{{site.baseurl}}/teca.html">TECA</a>
+                        <a class="dropdown-item" href="{{site.baseurl}}/metrics.html">Metrics list</a>
                     </div>
                 </li>
                 <li class="nav-item{% if page.url == '/results/' %} active {% endif %}">

--- a/capabilities.md
+++ b/capabilities.md
@@ -125,13 +125,13 @@ refer to ILAMB instead of IOMB.</p>
 Community contributed packages
 </h3>
 <a href="https://github.com/nick-klingaman/ASoP">Analysing Scales of Precipitation (ASoP)</a>
-<br>The ASoP package offers two workflows: one that characterizes the spectrum of precipitation intensity (ASoP Spectral), and another that measures spatial and temporal coherence of precipitation (ASoP Coherence). It can operate on a variety of temporal and spatial scales for both climate models and observations. <a href="https://gmd.copernicus.org/articles/10/57/2017/">Link to reference.<\a>
+<br>The ASoP package offers two workflows: one that characterizes the spectrum of precipitation intensity (ASoP Spectral), and another that measures spatial and temporal coherence of precipitation (ASoP Coherence). It can operate on a variety of temporal and spatial scales for both climate models and observations. <a href="https://gmd.copernicus.org/articles/10/57/2017/">Link to reference.</a>
 <br><br>
 <a href="https://github.com/zarzycki/cymep">Cyclone Metrics Package (CyMeP)</a>
-<br>CyMeP offers a suite of metrics for analyzing tropical cyclone trajectories on global or regional scales. This package includes a "scorecard" presentation for easy metrics comparisons along with maps of spatial quantities like storm genesis and track bias. <a href="https://doi.org/10.1175/JAMC-D-20-0149.1">Link to reference.<\a>
+<br>CyMeP offers a suite of metrics for analyzing tropical cyclone trajectories on global or regional scales. This package includes a "scorecard" presentation for easy metrics comparisons along with maps of spatial quantities like storm genesis and track bias. <a href="https://doi.org/10.1175/JAMC-D-20-0149.1">Link to reference.</a>
 <br><br>
 <a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics</a>
-<br>The Drought Metrics package includes a complete suite of metrics for characterizing drought among multiple regions. It uses principle feature analysis to narrow down a subset of the most important metrics that characterize drought in an area. <a href="https://doi.org/10.1175/JHM-D-20-0314.1">Link to reference.<\a>
+<br>The Drought Metrics package includes a complete suite of metrics for characterizing regional drought. It also narrows down a subset of the most important metrics that characterize drought in that area. <a href="https://doi.org/10.1175/JHM-D-20-0314.1">Link to reference.</a>
 <br><br>
 <a href="https://github.com/LBL-EESA/TECA">The Toolkit for Extremes Climate Analysis (TECA)</a>
 <br>TECA specializes in extreme event detection for phenomena such as tropical cyclones, extra-tropical cyclones, and atmospheric rivers. <a href="https://doi.org/10.1016/j.procs.2012.04.093">Link to reference.</a>

--- a/capabilities.md
+++ b/capabilities.md
@@ -41,9 +41,11 @@ the context of all previous generations of AMIP and CMIP.
 <a border="0" href="pmp.html"><img src="{{site.baseurl}}/assets/images/pmp_cover_side_sm.png"></a>
 </center>
 <br>
+<strong>Sub-modules</strong>:
+ENSO, Mean Climate, MJO metrics, Extra-tropical modes of variability, Monsoon metrics(Sperber and Wang), Precipitation variability, Sub-daily precipitation
 <strong>Quick links</strong>:
 <a href="https://github.com/PCMDI/pcmdi_metrics">Repository</a>, 
-<a href="https://github.com/PCMDI/pcmdi_metrics/wiki/Install-using-Anaconda">Installation</a>, and
+<a href="https://pcmdi.github.io/pcmdi_metrics/install.html">Installation</a>, and
 <a href="results/physical.html">Results</a>
 </div>
 
@@ -74,7 +76,7 @@ rapidly understand the underlying drivers of those responses.
 </center>
 <br>
 <strong>Quick links</strong>:&nbsp;
-<a href="https://bitbucket.org/ncollier/ilamb">Repository</a>,
+<a href="https://github.com/rubisco-sfa/ILAMB">Repository</a>,
 <a href="https://www.ilamb.org/doc/install.html">Installation</a>, and
 <a href="https://www.ilamb.org/doc/tutorial.html">Tutorials</a>
 </div>
@@ -105,28 +107,9 @@ rapidly understand the underlying drivers of those responses.
 refer to ILAMB instead of IOMB.</p>
 <br>
 <strong>Quick links</strong>:&nbsp;
-<a href="https://bitbucket.org/ncollier/ilamb">Repository</a>,
+<a href="https://github.com/rubisco-sfa/ILAMB">Repository</a>,
 <a href="https://www.ilamb.org/doc/install.html">Installation</a>, and
 <a href="https://www.ilamb.org/doc/tutorial.html">Tutorials</a>
-</div>
-
-******
-
-<!-- TECA -->
-<div class="span4 box">
-<h3>
-<a class="reference internal" href="teca.html">The Toolkit for Extremes
-Climate Analysis (TECA)</a>
-</h3>
-<p>
-TECA is a general purpose tool for detecting discrete events in climate model
-output.
-</p>
-<img src="">
-<strong>Quick links</strong>:&nbsp;
-<a href="https://github.com/LBL-EESA/TECA">Repository</a>,
-<a href="https://github.com/LBL-EESA/TECA_superbuild">Installation</a>,
-<a href="https://github.com/LBL-EESA/TECA/blob/master/doc/teca_users_guide.pdf">Documentation</a>
 </div>
 
 ******
@@ -141,4 +124,5 @@ Community contributed packages
 <a href="https://github.com/zarzycki/cymep">Cyclone Metrics Package (CyMeP)</a>
 <br>
 <a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics</a>
+<a href="https://github.com/LBL-EESA/TECA">The Toolkit for Extremes Climate Analysis (TECA)</a>
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -41,8 +41,9 @@ the context of all previous generations of AMIP and CMIP.
 <a border="0" href="pmp.html"><img src="{{site.baseurl}}/assets/images/pmp_cover_side_sm.png"></a>
 </center>
 <br>
-<strong>Sub-modules</strong>:
+<strong>Metrics include</strong>:
 ENSO, Mean Climate, MJO metrics, Extra-tropical modes of variability, Monsoon metrics(Sperber and Wang), Precipitation variability, Sub-daily precipitation
+<br>
 <strong>Quick links</strong>:
 <a href="https://github.com/PCMDI/pcmdi_metrics">Repository</a>, 
 <a href="https://pcmdi.github.io/pcmdi_metrics/install.html">Installation</a>, and
@@ -75,6 +76,8 @@ rapidly understand the underlying drivers of those responses.
 <a border="0" href="ilamb.html"><img src="{{site.baseurl}}/assets/images/ilamb_biomass_sm.png"></a>
 </center>
 <br>
+<strong>Metrics include</strong> Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Radiation and Energy Cycle, Forcings, Relationships
+<br>
 <strong>Quick links</strong>:&nbsp;
 <a href="https://github.com/rubisco-sfa/ILAMB">Repository</a>,
 <a href="https://www.ilamb.org/doc/install.html">Installation</a>, and
@@ -105,6 +108,8 @@ rapidly understand the underlying drivers of those responses.
 </center>
 <p>IOMB uses the same code base as ILAMB (described above). The links below
 refer to ILAMB instead of IOMB.</p>
+<br>
+<strong>Metrics include</strong> Chemical Oceanography, Physical Oceanography, SeaAirFluxes
 <br>
 <strong>Quick links</strong>:&nbsp;
 <a href="https://github.com/rubisco-sfa/ILAMB">Repository</a>,

--- a/capabilities.md
+++ b/capabilities.md
@@ -42,7 +42,7 @@ the context of all previous generations of AMIP and CMIP.
 </center>
 <br>
 <strong>Metrics include</strong>:
-ENSO, Mean Climate, MJO metrics, Extra-tropical modes of variability, Monsoon metrics(Sperber and Wang), Precipitation variability, Sub-daily precipitation
+ENSO, Mean Climate, MJO metrics, Extra-tropical modes of variability, Monsoon metrics (Sperber and Wang), Precipitation variability, Sub-daily precipitation
 <br>
 <strong>Quick links</strong>:
 <a href="https://github.com/PCMDI/pcmdi_metrics">Repository</a>, 
@@ -76,7 +76,7 @@ rapidly understand the underlying drivers of those responses.
 <a border="0" href="ilamb.html"><img src="{{site.baseurl}}/assets/images/ilamb_biomass_sm.png"></a>
 </center>
 <br>
-<strong>Metrics include</strong> Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Radiation and Energy Cycle, Forcings, Relationships
+<strong>Metrics include</strong>: Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, Relationships
 <br>
 <strong>Quick links</strong>:&nbsp;
 <a href="https://github.com/rubisco-sfa/ILAMB">Repository</a>,
@@ -109,7 +109,7 @@ rapidly understand the underlying drivers of those responses.
 <p>IOMB uses the same code base as ILAMB (described above). The links below
 refer to ILAMB instead of IOMB.</p>
 <br>
-<strong>Metrics include</strong> Chemical Oceanography, Physical Oceanography, SeaAirFluxes
+<strong>Metrics include</strong>: Chemical Oceanography, Physical Oceanography, SeaAirFluxes
 <br>
 <strong>Quick links</strong>:&nbsp;
 <a href="https://github.com/rubisco-sfa/ILAMB">Repository</a>,
@@ -124,10 +124,11 @@ refer to ILAMB instead of IOMB.</p>
 <h3>
 Community contributed packages
 </h3>
-<a href="https://github.com/nick-klingaman/ASoP">Analysing Scales of Precipitation (ASoP)</a>
+<a href="https://github.com/nick-klingaman/ASoP">Analysing Scales of Precipitation (ASoP)</a> Metrics: Spectral and Coherence analysis of precipitation intensity
 <br>
-<a href="https://github.com/zarzycki/cymep">Cyclone Metrics Package (CyMeP)</a>
+<a href="https://github.com/zarzycki/cymep">Cyclone Metrics Package (CyMeP)</a> Metrics: Tropical cyclone metrics
 <br>
-<a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics</a>
+<a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics</a> Metrics: Monthly mean precipitation, Seasonality, Fractional area of drought, Proportion of dry months, Intesity, Probability of drought initiation, Probability of drought termination, Overal score
+<br>
 <a href="https://github.com/LBL-EESA/TECA">The Toolkit for Extremes Climate Analysis (TECA)</a>
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -125,14 +125,14 @@ refer to ILAMB instead of IOMB.</p>
 Community contributed packages
 </h3>
 <a href="https://github.com/nick-klingaman/ASoP">Analysing Scales of Precipitation (ASoP)</a>
-<br>Spectral and Coherence analysis of precipitation intensity over one or more regions.
+<br>The ASoP package offers two workflows: one that characterizes the spectrum of precipitation intensity (ASoP Spectral), and another that measures spatial and temporal coherence of precipitation (ASoP Coherence). It can operate on a variety of temporal and spatial scales for both climate models and observations. <a href="https://gmd.copernicus.org/articles/10/57/2017/">Link to reference.<\a>
 <br><br>
 <a href="https://github.com/zarzycki/cymep">Cyclone Metrics Package (CyMeP)</a>
-<br>Spatial and temporal metrics for tropical cyclone trajectories. Provides figures to compare seasonal and interannual values of storm characteristics along with maps showing density, bias, and other measures.
+<br>CyMeP offers a suite of metrics for analyzing tropical cyclone trajectories on global or regional scales. This package includes a "scorecard" presentation for easy metrics comparisons along with maps of spatial quantities like storm genesis and track bias. <a href="https://doi.org/10.1175/JAMC-D-20-0149.1">Link to reference.<\a>
 <br><br>
 <a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics</a>
-<br>Metrics to characterize seasonal and mean precipitation along with drought initiation, termination, intensity, and converage.
+<br>The Drought Metrics package includes a complete suite of metrics for characterizing drought among multiple regions. It uses principle feature analysis to narrow down a subset of the most important metrics that characterize drought in an area. <a href="https://doi.org/10.1175/JHM-D-20-0314.1">Link to reference.<\a>
 <br><br>
 <a href="https://github.com/LBL-EESA/TECA">The Toolkit for Extremes Climate Analysis (TECA)</a>
-<br>Extreme event detection.
+<br>TECA specializes in extreme event detection for phenomena such as tropical cyclones, extra-tropical cyclones, and atmospheric rivers. <a href="https://doi.org/10.1016/j.procs.2012.04.093">Link to reference.</a>
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -124,11 +124,11 @@ refer to ILAMB instead of IOMB.</p>
 <h3>
 Community contributed packages
 </h3>
-<a href="https://github.com/nick-klingaman/ASoP">Analysing Scales of Precipitation (ASoP)</a> Metrics: Spectral and Coherence analysis of precipitation intensity
+<a href="https://github.com/nick-klingaman/ASoP">Analysing Scales of Precipitation (ASoP)</a>: Spectral and Coherence analysis of precipitation intensity over one or more regions.
 <br>
-<a href="https://github.com/zarzycki/cymep">Cyclone Metrics Package (CyMeP)</a> Metrics: Tropical cyclone metrics
+<a href="https://github.com/zarzycki/cymep">Cyclone Metrics Package (CyMeP)</a>: Spatial and temporal metrics for tropical cyclone trajectories. Provides figures to compare seasonal and interannual values of storm characteristics along with maps showing density, bias, and other measures.
 <br>
-<a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics</a> Metrics: Monthly mean precipitation, Seasonality, Fractional area of drought, Proportion of dry months, Intesity, Probability of drought initiation, Probability of drought termination, Overal score
+<a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics</a>: Metrics to characterize seasonal and mean precipitation along with drought initiation, termination, intensity, and converage.
 <br>
-<a href="https://github.com/LBL-EESA/TECA">The Toolkit for Extremes Climate Analysis (TECA)</a>
+<a href="https://github.com/LBL-EESA/TECA">The Toolkit for Extremes Climate Analysis (TECA)</a>: Extreme event detection.
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -5,7 +5,7 @@ title: Capabilities
 
 ## Capabilities Overview
 
-The capabilities currently contributing to CMEC are briefly highlighted below. For a full list of all the metrics available in each package, see the <a href="metrics.html">Metrics table</a>.
+The capabilities currently contributing to CMEC are briefly highlighted below. For a full list of all the metrics available in each package, see the <a href="metrics.html">Model Evaluation Packages table</a>.
 
 ******
 <!-- CMEC driver -->

--- a/capabilities.md
+++ b/capabilities.md
@@ -124,11 +124,15 @@ refer to ILAMB instead of IOMB.</p>
 <h3>
 Community contributed packages
 </h3>
-<a href="https://github.com/nick-klingaman/ASoP">Analysing Scales of Precipitation (ASoP)</a>: Spectral and Coherence analysis of precipitation intensity over one or more regions.
-<br>
-<a href="https://github.com/zarzycki/cymep">Cyclone Metrics Package (CyMeP)</a>: Spatial and temporal metrics for tropical cyclone trajectories. Provides figures to compare seasonal and interannual values of storm characteristics along with maps showing density, bias, and other measures.
-<br>
-<a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics</a>: Metrics to characterize seasonal and mean precipitation along with drought initiation, termination, intensity, and converage.
-<br>
-<a href="https://github.com/LBL-EESA/TECA">The Toolkit for Extremes Climate Analysis (TECA)</a>: Extreme event detection.
+<a href="https://github.com/nick-klingaman/ASoP">Analysing Scales of Precipitation (ASoP)</a>
+<br>Spectral and Coherence analysis of precipitation intensity over one or more regions.
+<br><br>
+<a href="https://github.com/zarzycki/cymep">Cyclone Metrics Package (CyMeP)</a>
+<br>Spatial and temporal metrics for tropical cyclone trajectories. Provides figures to compare seasonal and interannual values of storm characteristics along with maps showing density, bias, and other measures.
+<br><br>
+<a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics</a>
+<br>Metrics to characterize seasonal and mean precipitation along with drought initiation, termination, intensity, and converage.
+<br><br>
+<a href="https://github.com/LBL-EESA/TECA">The Toolkit for Extremes Climate Analysis (TECA)</a>
+<br>Extreme event detection.
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -5,7 +5,7 @@ title: Capabilities
 
 ## Capabilities Overview
 
-The capabilities currently contributing to CMEC are briefly highlighted below:
+The capabilities currently contributing to CMEC are briefly highlighted below. For a full list of all the metrics available in each package, see the <a href="metrics.html">Metrics table</a>.
 
 ******
 <!-- CMEC driver -->

--- a/capabilities.md
+++ b/capabilities.md
@@ -42,7 +42,7 @@ the context of all previous generations of AMIP and CMIP.
 </center>
 <br>
 <strong>Metrics include</strong>:
-ENSO, Mean Climate, MJO metrics, Extra-tropical modes of variability, Monsoon metrics (Sperber and Wang), Precipitation variability, Sub-daily precipitation
+El Niño-Southern Oscillation (ENSO), Mean Climate, Madden-Julian Oscillation (MJO) metrics, Extra-tropical modes of variability, Monsoon metrics (Sperber and Wang), Precipitation variability, Sub-daily precipitation
 <br>
 <strong>Quick links</strong>:
 <a href="https://github.com/PCMDI/pcmdi_metrics">Repository</a>, 

--- a/contact.md
+++ b/contact.md
@@ -10,15 +10,10 @@ Paul Ullrich \\
 
 ## PMP: 
 
-Peter J. Gleckler \\
-<gleckler1@llnl.gov>
+Jiwoo Lee \\
+<lee1043@llnl.gov>
 
 ## ILAMB and IOMB:
 
 Forrest M. Hoffman \\
 <forrest@climatemodeling.org>
-
-## TECA:
-
-William D. Collins \\
-<wdcollins@lbl.gov>

--- a/ilamb.md
+++ b/ilamb.md
@@ -90,7 +90,7 @@ design philosophy and implementation are described by
 <a href="https://github.com/rubisco-sfa/ILAMB">Repository</a>,
 <a href="https://www.ilamb.org/doc/install.html">Installation</a>,
 <a href="https://www.ilamb.org/doc/tutorial.html">Tutorials</a>,
-<a href="https://www.ilamb.org/CMIP5/esmHistorical">CMIP5 Results</a>,
+<a href="https://www.ilamb.org/CMIP5/historical/">CMIP5 Results</a>,
 and <a href="https://www.ilamb.org/CLM/">CLM Results</a>
 <br>
 <b>Contact:</b> Forrest M. Hoffman (forrest@climatemodeling.org)

--- a/ilamb.md
+++ b/ilamb.md
@@ -87,7 +87,7 @@ design philosophy and implementation are described by
 [Collier et al. (2018)](https://doi.org/10.1029/2018MS001354).
 
 <strong>Quick links</strong>:&nbsp;
-<a href="https://bitbucket.org/ncollier/ilamb">Repository</a>,
+<a href="https://github.com/rubisco-sfa/ILAMB">Repository</a>,
 <a href="https://www.ilamb.org/doc/install.html">Installation</a>,
 <a href="https://www.ilamb.org/doc/tutorial.html">Tutorials</a>,
 <a href="https://www.ilamb.org/CMIP5/esmHistorical">CMIP5 Results</a>,

--- a/metrics.md
+++ b/metrics.md
@@ -54,7 +54,19 @@ This table describes the metrics and diagnostics available in CMEC packages
   </tr>
   <tr>
     <td>Model Diagnostics Task Force (MDTF) Diagnostics</td>
-    <td><b>Process Oriented Diagnostics (PODs)</b>: ENSO_MSE, ENSO_RWS, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/EOF_500hPa.html">Extratropical Variance</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/MJO_prop_amp.html">Madden-Julian Oscillation Propogation and Amplitude</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/MJO_suite.html">Madden-Julian Oscillation Spectra and Phasing</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/MJO_teleconnection.html">Madden-Julian Oscillation Teleconnections</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/SM_ET_coupling.html">Coupling between Soil Moisture and Evapotranspiration</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/Wheeler_Kiladis.html">Wavenumber-Frequency Spectra</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/convective_transition_diag.html">Convective Transition Diagnostics</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/mixed_layer_depth.html">Mixed Layer Depth</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/ocn_surf_flux_diag.html">Ocean Sufrace Latent Heat Flux Diagnostic</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/precip_diurnal_cycle.html">Diurnal Cycle of Precipitation</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/temp_extremes_distshape.html">Surface Temperature Extremes and Distribution Shape</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/tropical_pacific_sea_level.html">Tropical Pacific Sea Level Diagnostic</a></td>
+    <td><b>Process Oriented Diagnostics (PODs)</b>:
+    <br>ENSO_MSE
+    <br>ENSO_RWS
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/EOF_500hPa.html">Extratropical Variance</a>
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/MJO_prop_amp.html">Madden-Julian Oscillation Propogation and Amplitude</a>
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/MJO_suite.html">Madden-Julian Oscillation Spectra and Phasing</a>
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/MJO_teleconnection.html">Madden-Julian Oscillation Teleconnections</a>
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/SM_ET_coupling.html">Coupling between Soil Moisture and Evapotranspiration</a>
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/Wheeler_Kiladis.html">Wavenumber-Frequency Spectra</a><br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/convective_transition_diag.html">Convective Transition Diagnostics</a>
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/mixed_layer_depth.html">Mixed Layer Depth</a><br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/ocn_surf_flux_diag.html">Ocean Sufrace Latent Heat Flux Diagnostic</a>
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/precip_diurnal_cycle.html">Diurnal Cycle of Precipitation</a>
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/temp_extremes_distshape.html">Surface Temperature Extremes and Distribution Shape</a>
+    <br><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/tropical_pacific_sea_level.html">Tropical Pacific Sea Level Diagnostic</a></td>
     <td><a href="https://github.com/NOAA-GFDL/MDTF-diagnostics">Github repository</a></td>
     <td><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/">Documentation website</a><br><a href="https://www.gfdl.noaa.gov/mdtf-diagnostics/">Project Website</a></td>
   </tr>

--- a/metrics.md
+++ b/metrics.md
@@ -1,13 +1,13 @@
- --
- layout: default
- title: Metrics
- --
+---
+layout: default
+title: Metrics
+---
  
- ## Metrics Table
+## Metrics Table
  
- This table describes the metrics available in CMEC packages
+This table describes the metrics available in CMEC packages
  
- <table>
+<table>
   <tr>
     <th>Package</th>
     <th>Metrics</th>

--- a/metrics.md
+++ b/metrics.md
@@ -1,7 +1,7 @@
- ---
+ --
  layout: default
  title: Metrics
- ---
+ --
  
  ## Metrics Table
  
@@ -16,38 +16,66 @@
   </tr>
   <tr>
     <td>Analyzing Scales of Precipitation (ASoP)</td>
-    <td>  </td>
-    <td>https://github.com/nick-klingaman/ASoP</td>
-    <td>https://github.com/nick-klingaman/ASoP/blob/master/ASoP_guide.pdf</td>
+    <td>Coherence: Temporal intermittency, Spatial intermittency
+  Coherence figures: correlations of precipitation in space and time over regional blocks.
+Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actual and fractional contribution to precipitation rate by intensity range, 
+</td>
+    <td><a href="https://github.com/nick-klingaman/ASoP">ASoP repository</a>a></td>
+    <td><a href="https://github.com/nick-klingaman/ASoP/blob/master/ASoP_guide.pdf">User Guide</a></td>
   </tr>
   <tr>
     <td>Cyclone Metrics Package (CyMeP)</td>
-    <td>  </td>
-    <td>https://github.com/zarzycki/cymep</td>
-    <td>https://github.com/zarzycki/cymep#cymep-cyclone-metrics-package</td>
+    <td> Storm characteristics: tropical cyclone days, storm genesis, storm intensity (minimum sea level pressure, maximum 10-meter wind speed, accumulated cyclone energy,  pressure accumulated cyclone energy), latitude of lifetime-maximum intensity
+    <b>Statistics: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
+    <b>Figures: Scorecards, Spatial density maps, taylor diagrams, interannual cycle line plots, seasonal cycle line plots
+    </td>
+    <td><a href="https://github.com/zarzycki/cymep">CyMeP repository</a></td>
+    <td><a href="https://github.com/zarzycki/cymep#cymep-cyclone-metrics-package">CyMeP README</a></td>
   </tr>
   <tr>
     <td>Drought Metrics</td>
-    <td>   </td>
-    <td>https://github.com/cmecmetrics/Drought_Metrics</td>
-    <td>https://github.com/cmecmetrics/Drought_Metrics#drought_metrics</td>
+    <td>Mean precipitation, mean SPI6, Mean SPI36, Seasonality of  Precipitation, Long term monthly mean, Fractional area coverage of drought, Proportion of dry months, Count of dry months, Drought intensity, Probability of drought initiation, probability of drought termination, overall score</td>
+    <td><a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics repository</a></td>
+    <td><a href="https://github.com/cmecmetrics/Drought_Metrics#drought_metrics">Drought Metrics README</a></td>
   </tr>
   <tr>
     <td>International Land Model Benchmarking (ILAMB)</td>
-    <td>   </td>
-    <td>https://github.com/rubisco-sfa/ILAMB</td>
-    <td>https://www.ilamb.org/doc/</td>
+    <td>Diagnostics figures: contour maps, time series plots, Taylor Diagrams
+    <b>Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <b>Metrics categories: Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).
+</td>
+    <td><a href="https://github.com/rubisco-sfa/ILAMB">ILAMB repository</a></td>
+    <td><a href="https://www.ilamb.org/doc/">ILAMB documentation</a></td>
+  </tr>
+  <tr>
+    <td>International Ocean Model Benchmarking (IOMB)</td>
+    <td>Diagnostics figures: contour maps, time series plots, Taylor Diagrams
+    <b>Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <b>Metrics categories: Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.
+</td>
+    <td><a href="https://github.com/rubisco-sfa/ILAMB">IOMB repository</a> (shared with ILAMB)</td>
+    <td><a href="https://www.ilamb.org/doc/">IOMB documentation</a> (shared with ILAMB)</td>
   </tr>
   <tr>
     <td>Model Diagnostics Task Force (MDTF) Diagnostics</td>
-    <td>  </td>
-    <td>https://github.com/NOAA-GFDL/MDTF-diagnostics</td>
-    <td>https://mdtf-diagnostics.readthedocs.io/en/latest/</td>
+    <td>PODs: ENSO_MSE, ENSO_RWS, Extratropical Variance, Madden-Julian Oscillation Propogation and Amplitude, Madden-Julian Oscillation Spectra and Phasing, Madden-Julian Oscillation Teleconnections, Coupling between Soil Moisture and Evapotranspiration, Wavenumber-Frequency Spectra, Convective Transition Diagnostics, Mixed Layer Depth, Ocean Sufrace Latent Heat Flux Diagnostic, Diurnal Cycle of Precipitation, Surface Temperature Extremes and Distribution Shape, Tropical Pacific Sea Level Diagnostic</td>
+    <td><a href="https://github.com/NOAA-GFDL/MDTF-diagnostics">MDTF Diagnostics repository</a></td>
+    <td><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/">MDTF Diagnostics documentation</a></td>
   </tr>
   <tr>
     <td>PCMDI Metrics Package (PMP)</td>
-    <td>  </td>
-    <td>https://pcmdi.github.io/pcmdi_metrics/</td>
-    <td>https://github.com/PCMDI/pcmdi_metrics</td>
+    <td>Mean Climate: bias_xy, cor_xy, mae_xy, mean-obs_xy, mean_xy, rms_devzm, rms_xy, rms_xyt, rms_y, rmsc_xy, std-obs_xy, std-obs_xyt, std_xy, std_xy_devzm, std_xyt
+    <b>Monsoon (Wang): correlation, rmsn, threat score
+    <b>Monsoon (Sperber): decay index, duration, onset index, slope
+    <b>Diurnal Cycle: harmonic 1, 2, and 3: amp_avg_lnd, pha_avg_lnd, amp_avg_ocn, pha_avg_ocn
+    <b>Modes of Variability: bias, bias_glo, cor, cor_glo, frac, frac_cbf_regrid, mean, mean_glo, rms, rms_glo, rmsc, rmsc_glo, stdv_pc, std_pc_ratio_to_obs, tcor_cbf_vs_eof_pc
+    <b>MJO metrics: east power, west power, East-west power ratio
+    <b>ENSO_perf: BiasPrLatRmse, BiasPrLonRmse, BiasSSTLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoDuration, EnsoSeasonality, EnsoSstDiversity_2, EnsoSSTLonRmse, EnsoSstSkew, EnsoSstTsRmse, SeasonalPrLatRmse, SeasonalPrLonRmse, SeasonalSstLonRmse, SeasonalTauxLonRmse
+    <b>ENSO_tel: EnsoAmpl, EnsoPrMapDjfCorr, EnsoPrMapDjfRmse, EnsoPrMapDjfStd, EnsoPrMapJjaCorr, EnsoPrMapJjaRmse, EnsoPrMapJjaStd, EnsoSeasonality, EnsoSstLonRmse, EnsoSstMapDjfCorr, EnsoSstMapDjfRmse, EnsoSstMapDjfStd, EnsoSstMapJjaCorr, EnsoSstMapJjaRmse, EnsoSstMapJjaStd
+    <b>ENSO_proc: BiasSstLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoFbSstTaux, EnsoFbSstThf, EnsoSeasonality, EnsoSstLonRmse, EnsoSstSkew, EnsodSstOce_2
+    <b>Precipitation variability: Forced annual, forced semi-annual, unforced interannual, unforced seasonal-annual, unforced sub-seasonal, unforced synoptic
+    </td>
+    <td><a href="https://github.com/PCMDI/pcmdi_metrics">PCMDI metrics repository</a></td>
+    <td><a href="https://pcmdi.github.io/pcmdi_metrics/">PCMDI Metrics documentation</a></td>
   </tr>
 </table> 

--- a/metrics.md
+++ b/metrics.md
@@ -3,60 +3,60 @@ layout: default
 title: Metrics
 ---
  
-## Metrics Table
+## Model Evaluation Packages
  
-This table describes the metrics available in CMEC packages
+This table describes the metrics and diagnostics available in CMEC packages
  
 <table>
   <tr>
     <th>Package</th>
-    <th>Metrics</th>
+    <th>Contents</th>
     <th>Source</th>
     <th>Documentation</th>
   </tr>
   <tr>
     <td>Analyzing Scales of Precipitation (ASoP)</td>
     <td><b>Coherence</b>: Temporal intermittency metrics, spatial intermittency metrics, plots of correlations of precipitation in space and time over regional blocks.
-    <br><b>Spectral</b>: Histogram overlap metric, plots of 1d histograms of precipitation, maps of actual and fractional contribution to precipitation rate by intensity range</td>
+    <br><b>Spectral</b>: Histogram overlap metric, file (for each dataset) containing 100-bin distribution of counts over the time period for each gridpoint, plots of 1d histograms of precipitation, maps of actual and fractional contribution to precipitation rate by intensity range</td>
     <td><a href="https://github.com/nick-klingaman/ASoP">Github repository</a></td>
     <td><a href="https://github.com/nick-klingaman/ASoP/blob/master/ASoP_guide.pdf">User Guide</a></td>
   </tr>
   <tr>
     <td>Cyclone Metrics Package (CyMeP)</td>
-    <td><b>Statistics</b>: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
+    <td><b>Statistics</b>: mean, bias, Pearson correlation, Spearman correlation, hit rate, false alarm ratio
     <br>Statistics measure the following storm characteristics: tropical cyclone days, storm genesis, storm intensity (minimum sea level pressure, maximum 10-meter wind speed, accumulated cyclone energy,  pressure accumulated cyclone energy), latitude of lifetime-maximum intensity
-    <br><b>Figures</b>: Scorecards, Spatial density maps, taylor diagrams, interannual cycle line plots, seasonal cycle line plots</td>
+    <br><b>Figures</b>: Scorecards, cyclone trajectories, spatial density maps, Taylor diagrams, interannual cycle line plots, seasonal cycle line plots</td>
     <td><a href="https://github.com/zarzycki/cymep">Github repository</a></td>
     <td><a href="https://github.com/zarzycki/cymep#cymep-cyclone-metrics-package">CyMeP README</a></td>
   </tr>
   <tr>
     <td>Drought Metrics</td>
-    <td><b>Metrics</b>: Mean precipitation, mean SPI6, Mean SPI36, Seasonality of  Precipitation, Long term monthly mean, Fractional area coverage of drought, Proportion of dry months, Count of dry months, Drought intensity, Probability of drought initiation, Probability of drought termination, Overall score
-    <br><b>Figures</b>: Taylor diagram, heatmap</td>
+    <td><b>Metrics</b>: Mean precipitation, mean SPI6, mean SPI36, seasonality of  precipitation, long term monthly mean, fractional area coverage of drought, proportion of dry months, count of dry months, drought intensity, probability of drought initiation, probability of drought termination, total score
+    <br><b>Figures</b>: Taylor diagram, heatmap of total scores</td>
     <td><a href="https://github.com/cmecmetrics/Drought_Metrics">Github repository</a></td>
     <td><a href="https://github.com/cmecmetrics/Drought_Metrics#drought_metrics">Drought Metrics README</a></td>
   </tr>
   <tr>
     <td>International Land Model Benchmarking (ILAMB)</td>
-    <td><b>Metrics</b>: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <td><b>Metrics</b>: A set of scores for spatial and temporal statistics of a model compared with observations for different quantities. Scores include overall score, bias score, RMSE score, and others.
     <br>Metrics categories include Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).
-    <br><b>Figures</b>: contour maps, time series plots, Taylor Diagrams</td>
+    <br><b>Figures</b>: contour maps, time series plots, Taylor diagrams</td>
     <td><a href="https://github.com/rubisco-sfa/ILAMB">Github repository</a></td>
     <td><a href="https://www.ilamb.org/doc/">Documentation website</a></td>
   </tr>
   <tr>
     <td>International Ocean Model Benchmarking (IOMB)</td>
-    <td><b>Metrics</b>: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <td><b>Metrics</b>: A set of scores that account for spatial and temporal statistics of a model compared with observations for different quantities. Scores include overall score, bias score, RMSE score, and others.
     <br>Metrics categories include Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.
-    <br><b>Figures</b>: contour maps, time series plots, Taylor Diagrams</td>
+    <br><b>Figures</b>: contour maps, time series plots, Taylor diagrams</td>
     <td><a href="https://github.com/rubisco-sfa/ILAMB">Github repository</a> (shared with ILAMB)</td>
     <td><a href="https://www.ilamb.org/doc/">Documentation website</a> (shared with ILAMB)</td>
   </tr>
   <tr>
     <td>Model Diagnostics Task Force (MDTF) Diagnostics</td>
-    <td><b>Process Oriented Diagnostics (PODs)</b>: ENSO_MSE, ENSO_RWS, Extratropical Variance, Madden-Julian Oscillation Propogation and Amplitude, Madden-Julian Oscillation Spectra and Phasing, Madden-Julian Oscillation Teleconnections, Coupling between Soil Moisture and Evapotranspiration, Wavenumber-Frequency Spectra, Convective Transition Diagnostics, Mixed Layer Depth, Ocean Sufrace Latent Heat Flux Diagnostic, Diurnal Cycle of Precipitation, Surface Temperature Extremes and Distribution Shape, Tropical Pacific Sea Level Diagnostic</td>
+    <td><b>Process Oriented Diagnostics (PODs)</b>: ENSO_MSE, ENSO_RWS, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/EOF_500hPa.html">Extratropical Variance</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/MJO_prop_amp.html">Madden-Julian Oscillation Propogation and Amplitude</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/MJO_suite.html">Madden-Julian Oscillation Spectra and Phasing</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/MJO_teleconnection.html">Madden-Julian Oscillation Teleconnections</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/SM_ET_coupling.html">Coupling between Soil Moisture and Evapotranspiration</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/Wheeler_Kiladis.html">Wavenumber-Frequency Spectra</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/convective_transition_diag.html">Convective Transition Diagnostics</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/mixed_layer_depth.html">Mixed Layer Depth</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/ocn_surf_flux_diag.html">Ocean Sufrace Latent Heat Flux Diagnostic</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/precip_diurnal_cycle.html">Diurnal Cycle of Precipitation</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/temp_extremes_distshape.html">Surface Temperature Extremes and Distribution Shape</a>, <a href="https://mdtf-diagnostics.readthedocs.io/en/latest/sphinx_pods/tropical_pacific_sea_level.html">Tropical Pacific Sea Level Diagnostic</a></td>
     <td><a href="https://github.com/NOAA-GFDL/MDTF-diagnostics">Github repository</a></td>
-    <td><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/">Documentation website</a></td>
+    <td><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/">Documentation website</a><br><a href="https://www.gfdl.noaa.gov/mdtf-diagnostics/">Project Website</a></td>
   </tr>
   <tr>
     <td>PCMDI Metrics Package (PMP)</td>

--- a/metrics.md
+++ b/metrics.md
@@ -24,9 +24,9 @@ Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actu
   </tr>
   <tr>
     <td>Cyclone Metrics Package (CyMeP)</td>
-    <td> Storm characteristics: tropical cyclone days, storm genesis, storm intensity (minimum sea level pressure, maximum 10-meter wind speed, accumulated cyclone energy,  pressure accumulated cyclone energy), latitude of lifetime-maximum intensity
-    Statistics: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
-    Figures: Scorecards, Spatial density maps, taylor diagrams, interannual cycle line plots, seasonal cycle line plots</td>
+    <td>Storm characteristics: tropical cyclone days, storm genesis, storm intensity (minimum sea level pressure, maximum 10-meter wind speed, accumulated cyclone energy,  pressure accumulated cyclone energy), latitude of lifetime-maximum intensity
+    <br>Statistics: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
+    <br>Figures: Scorecards, Spatial density maps, taylor diagrams, interannual cycle line plots, seasonal cycle line plots</td>
     <td><a href="https://github.com/zarzycki/cymep">CyMeP repository</a></td>
     <td><a href="https://github.com/zarzycki/cymep#cymep-cyclone-metrics-package">CyMeP README</a></td>
   </tr>
@@ -39,16 +39,16 @@ Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actu
   <tr>
     <td>International Land Model Benchmarking (ILAMB)</td>
     <td>Diagnostics figures: contour maps, time series plots, Taylor Diagrams
-    Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
-    Metrics categories: Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).</td>
+    <br>Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <br>Metrics categories: Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).</td>
     <td><a href="https://github.com/rubisco-sfa/ILAMB">ILAMB repository</a></td>
     <td><a href="https://www.ilamb.org/doc/">ILAMB documentation</a></td>
   </tr>
   <tr>
     <td>International Ocean Model Benchmarking (IOMB)</td>
     <td>Diagnostics figures: contour maps, time series plots, Taylor Diagrams
-    Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
-    Metrics categories: Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.</td>
+    <br>Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <br>Metrics categories: Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.</td>
     <td><a href="https://github.com/rubisco-sfa/ILAMB">IOMB repository</a> (shared with ILAMB)</td>
     <td><a href="https://www.ilamb.org/doc/">IOMB documentation</a> (shared with ILAMB)</td>
   </tr>
@@ -61,15 +61,15 @@ Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actu
   <tr>
     <td>PCMDI Metrics Package (PMP)</td>
     <td>Mean Climate: bias_xy, cor_xy, mae_xy, mean-obs_xy, mean_xy, rms_devzm, rms_xy, rms_xyt, rms_y, rmsc_xy, std-obs_xy, std-obs_xyt, std_xy, std_xy_devzm, std_xyt
-    Monsoon (Wang): correlation, rmsn, threat score
-    Monsoon (Sperber): decay index, duration, onset index, slope
-    Diurnal Cycle: harmonic 1, 2, and 3: amp_avg_lnd, pha_avg_lnd, amp_avg_ocn, pha_avg_ocn
-    Modes of Variability: bias, bias_glo, cor, cor_glo, frac, frac_cbf_regrid, mean, mean_glo, rms, rms_glo, rmsc, rmsc_glo, stdv_pc, std_pc_ratio_to_obs, tcor_cbf_vs_eof_pc
-    MJO metrics: east power, west power, East-west power ratio
-    ENSO_perf: BiasPrLatRmse, BiasPrLonRmse, BiasSSTLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoDuration, EnsoSeasonality, EnsoSstDiversity_2, EnsoSSTLonRmse, EnsoSstSkew, EnsoSstTsRmse, SeasonalPrLatRmse, SeasonalPrLonRmse, SeasonalSstLonRmse, SeasonalTauxLonRmse
-    ENSO_tel: EnsoAmpl, EnsoPrMapDjfCorr, EnsoPrMapDjfRmse, EnsoPrMapDjfStd, EnsoPrMapJjaCorr, EnsoPrMapJjaRmse, EnsoPrMapJjaStd, EnsoSeasonality, EnsoSstLonRmse, EnsoSstMapDjfCorr, EnsoSstMapDjfRmse, EnsoSstMapDjfStd, EnsoSstMapJjaCorr, EnsoSstMapJjaRmse, EnsoSstMapJjaStd
-    ENSO_proc: BiasSstLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoFbSstTaux, EnsoFbSstThf, EnsoSeasonality, EnsoSstLonRmse, EnsoSstSkew, EnsodSstOce_2
-    Precipitation variability: Forced annual, forced semi-annual, unforced interannual, unforced seasonal-annual, unforced sub-seasonal, unforced synoptic</td>
+    <br><b>Monsoon (Wang)</b>: correlation, rmsn, threat score
+    <br><b>Monsoon (Sperber)</b>: decay index, duration, onset index, slope
+    <br><b>Diurnal Cycle</b>: harmonic 1, 2, and 3: amp_avg_lnd, pha_avg_lnd, amp_avg_ocn, pha_avg_ocn
+    <br><b>Modes of Variability</b>: bias, bias_glo, cor, cor_glo, frac, frac_cbf_regrid, mean, mean_glo, rms, rms_glo, rmsc, rmsc_glo, stdv_pc, std_pc_ratio_to_obs, tcor_cbf_vs_eof_pc
+    <br><b>MJO metrics</b>: east power, west power, East-west power ratio
+    <br><b>ENSO_perf</b>: BiasPrLatRmse, BiasPrLonRmse, BiasSSTLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoDuration, EnsoSeasonality, EnsoSstDiversity_2, EnsoSSTLonRmse, EnsoSstSkew, EnsoSstTsRmse, SeasonalPrLatRmse, SeasonalPrLonRmse, SeasonalSstLonRmse, SeasonalTauxLonRmse
+    <br><b>ENSO_tel</b>: EnsoAmpl, EnsoPrMapDjfCorr, EnsoPrMapDjfRmse, EnsoPrMapDjfStd, EnsoPrMapJjaCorr, EnsoPrMapJjaRmse, EnsoPrMapJjaStd, EnsoSeasonality, EnsoSstLonRmse, EnsoSstMapDjfCorr, EnsoSstMapDjfRmse, EnsoSstMapDjfStd, EnsoSstMapJjaCorr, EnsoSstMapJjaRmse, EnsoSstMapJjaStd
+    <br><b>ENSO_proc</b>: BiasSstLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoFbSstTaux, EnsoFbSstThf, EnsoSeasonality, EnsoSstLonRmse, EnsoSstSkew, EnsodSstOce_2
+    <br><b>Precipitation variability</b>: Forced annual, forced semi-annual, unforced interannual, unforced seasonal-annual, unforced sub-seasonal, unforced synoptic</td>
     <td><a href="https://github.com/PCMDI/pcmdi_metrics">PCMDI metrics repository</a></td>
     <td><a href="https://pcmdi.github.io/pcmdi_metrics/">PCMDI Metrics documentation</a></td>
 </tr>

--- a/metrics.md
+++ b/metrics.md
@@ -16,9 +16,8 @@ This table describes the metrics available in CMEC packages
   </tr>
   <tr>
     <td>Analyzing Scales of Precipitation (ASoP)</td>
-    <td>Coherence: Temporal intermittency, Spatial intermittency
-  Coherence figures: correlations of precipitation in space and time over regional blocks.
-Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actual and fractional contribution to precipitation rate by intensity range</td>
+    <td><b>Coherence</b>: Temporal intermittency metrics, spatial intermittency metrics, plots of correlations of precipitation in space and time over regional blocks.
+    <br><b>Spectral</b>: Histogram overlap metric, plots of 1d histograms of precipitation, maps of actual and fractional contribution to precipitation rate by intensity range</td>
     <td><a href="https://github.com/nick-klingaman/ASoP">Github repository</a></td>
     <td><a href="https://github.com/nick-klingaman/ASoP/blob/master/ASoP_guide.pdf">User Guide</a></td>
   </tr>
@@ -60,15 +59,15 @@ Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actu
   </tr>
   <tr>
     <td>PCMDI Metrics Package (PMP)</td>
-    <td>Mean Climate: bias_xy, cor_xy, mae_xy, mean-obs_xy, mean_xy, rms_devzm, rms_xy, rms_xyt, rms_y, rmsc_xy, std-obs_xy, std-obs_xyt, std_xy, std_xy_devzm, std_xyt
-    <br><b>Monsoon (Wang)</b>: correlation, rmsn, threat score
-    <br><b>Monsoon (Sperber)</b>: decay index, duration, onset index, slope
-    <br><b>Diurnal Cycle</b>: harmonic 1, 2, and 3: amp_avg_lnd, pha_avg_lnd, amp_avg_ocn, pha_avg_ocn
-    <br><b>Modes of Variability</b>: bias, bias_glo, cor, cor_glo, frac, frac_cbf_regrid, mean, mean_glo, rms, rms_glo, rmsc, rmsc_glo, stdv_pc, std_pc_ratio_to_obs, tcor_cbf_vs_eof_pc
-    <br><b>MJO metrics</b>: east power, west power, East-west power ratio
-    <br><b>ENSO_perf</b>: BiasPrLatRmse, BiasPrLonRmse, BiasSSTLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoDuration, EnsoSeasonality, EnsoSstDiversity_2, EnsoSSTLonRmse, EnsoSstSkew, EnsoSstTsRmse, SeasonalPrLatRmse, SeasonalPrLonRmse, SeasonalSstLonRmse, SeasonalTauxLonRmse
-    <br><b>ENSO_tel</b>: EnsoAmpl, EnsoPrMapDjfCorr, EnsoPrMapDjfRmse, EnsoPrMapDjfStd, EnsoPrMapJjaCorr, EnsoPrMapJjaRmse, EnsoPrMapJjaStd, EnsoSeasonality, EnsoSstLonRmse, EnsoSstMapDjfCorr, EnsoSstMapDjfRmse, EnsoSstMapDjfStd, EnsoSstMapJjaCorr, EnsoSstMapJjaRmse, EnsoSstMapJjaStd
-    <br><b>ENSO_proc</b>: BiasSstLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoFbSstTaux, EnsoFbSstThf, EnsoSeasonality, EnsoSstLonRmse, EnsoSstSkew, EnsodSstOce_2
+    <td><b>Mean Climate</b>: Statistics that characterize atmospheric variables and compare models with observations, including bias, mean, correlation, root mean square error, and standard deviation.
+    <br><b>Monsoon (Wang)</b>: Correlation, rmsn, threat score for defined regions (North America, South America, North Africa, South Africa, Asia, Australia, and "all" monsoon domains).
+    <br><b>Monsoon (Sperber)</b>: Decay index, duration, onset index, slope for defined regions (All-India, Northern Australia, Sahel, Gulf of Guinea, North America, South America).
+    <br><b>Diurnal Cycle</b>: Daily mean precipitation, standard deviation of mean diurnal cycle, standard deviation of hourly means, standard deviation of daily means, Fourier harmonics (amplitude and phase) 
+    <br><b>Modes of Variability</b>: Statistics for the Northern Annular Mode, Northern Atlantic Oscillation, Sourthern Annular Mode, Pacific North American Pattern, Pacific Decadal Oscillation. 
+    <br><b>Madden-Julian Oscillation metrics</b>: East power, West power, East-west power ratio
+    <br><b>El Niño–Southern Oscillation (ENSO) performance</b>: Cold tongue bias, trade wind bias, dry equator bias, double intertropical convergence zone bias, seasonalities of biases, ENSO amplitude, ENSO life cycle, ENSO asymmetry, ENSO diversity
+    <br><b>El Niño–Southern Oscillation teleconnections</b>: ENSO amplitude, ENSO pattern, ENSO seasonality, DJF precipitation teleconnection, DJF surface temperature teleconnection, JJA precipitation teleconnection, JJA surface temperature teleconnection
+    <br><b>El Niño–Southern Oscillation processes</b>: Cold tongue bias, trade winds bias, ENSO pattern, ENSO amplitude, ENSO seasonality, ENSO asymmetry, ocean-atmosphere Bjerknes feedback (atmosphere branch, ocean-atmosphere branch, and ocean branch), balance of Bjerknes feedback and heat fluxes on sea surface temperature anomalies
     <br><b>Precipitation variability</b>: Forced annual, forced semi-annual, unforced interannual, unforced seasonal-annual, unforced sub-seasonal, unforced synoptic</td>
     <td><a href="https://github.com/PCMDI/pcmdi_metrics">Github repository</a></td>
     <td><a href="https://pcmdi.github.io/pcmdi_metrics/">Documentation website</a></td>

--- a/metrics.md
+++ b/metrics.md
@@ -1,0 +1,53 @@
+ ---
+ layout: default
+ title: Metrics
+ ---
+ 
+ ## Metrics Table
+ 
+ This table describes the metrics available in CMEC packages
+ 
+ <table>
+  <tr>
+    <th>Package</th>
+    <th>Metrics</th>
+    <th>Source</th>
+    <th>Documentation</th>
+  </tr>
+  <tr>
+    <td>Analyzing Scales of Precipitation (ASoP)</td>
+    <td>  </td>
+    <td>https://github.com/nick-klingaman/ASoP</td>
+    <td>https://github.com/nick-klingaman/ASoP/blob/master/ASoP_guide.pdf</td>
+  </tr>
+  <tr>
+    <td>Cyclone Metrics Package (CyMeP)</td>
+    <td>  </td>
+    <td>https://github.com/zarzycki/cymep</td>
+    <td>https://github.com/zarzycki/cymep#cymep-cyclone-metrics-package</td>
+  </tr>
+  <tr>
+    <td>Drought Metrics</td>
+    <td>   </td>
+    <td>https://github.com/cmecmetrics/Drought_Metrics</td>
+    <td>https://github.com/cmecmetrics/Drought_Metrics#drought_metrics</td>
+  </tr>
+  <tr>
+    <td>International Land Model Benchmarking (ILAMB)</td>
+    <td>   </td>
+    <td>https://github.com/rubisco-sfa/ILAMB</td>
+    <td>https://www.ilamb.org/doc/</td>
+  </tr>
+  <tr>
+    <td>Model Diagnostics Task Force (MDTF) Diagnostics</td>
+    <td>  </td>
+    <td>https://github.com/NOAA-GFDL/MDTF-diagnostics</td>
+    <td>https://mdtf-diagnostics.readthedocs.io/en/latest/</td>
+  </tr>
+  <tr>
+    <td>PCMDI Metrics Package (PMP)</td>
+    <td>  </td>
+    <td>https://pcmdi.github.io/pcmdi_metrics/</td>
+    <td>https://github.com/PCMDI/pcmdi_metrics</td>
+  </tr>
+</table> 

--- a/metrics.md
+++ b/metrics.md
@@ -19,44 +19,44 @@ This table describes the metrics available in CMEC packages
     <td>Coherence: Temporal intermittency, Spatial intermittency
   Coherence figures: correlations of precipitation in space and time over regional blocks.
 Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actual and fractional contribution to precipitation rate by intensity range</td>
-    <td><a href="https://github.com/nick-klingaman/ASoP">ASoP repository</a></td>
+    <td><a href="https://github.com/nick-klingaman/ASoP">Github repository</a></td>
     <td><a href="https://github.com/nick-klingaman/ASoP/blob/master/ASoP_guide.pdf">User Guide</a></td>
   </tr>
   <tr>
     <td>Cyclone Metrics Package (CyMeP)</td>
-    <td>Storm characteristics: tropical cyclone days, storm genesis, storm intensity (minimum sea level pressure, maximum 10-meter wind speed, accumulated cyclone energy,  pressure accumulated cyclone energy), latitude of lifetime-maximum intensity
-    <br>Statistics: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
-    <br>Figures: Scorecards, Spatial density maps, taylor diagrams, interannual cycle line plots, seasonal cycle line plots</td>
-    <td><a href="https://github.com/zarzycki/cymep">CyMeP repository</a></td>
+    <td><b>Storm characteristics</b>: tropical cyclone days, storm genesis, storm intensity (minimum sea level pressure, maximum 10-meter wind speed, accumulated cyclone energy,  pressure accumulated cyclone energy), latitude of lifetime-maximum intensity
+    <br><b>Statistics</b>: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
+    <br><b>Figures</b>: Scorecards, Spatial density maps, taylor diagrams, interannual cycle line plots, seasonal cycle line plots</td>
+    <td><a href="https://github.com/zarzycki/cymep">Github repository</a></td>
     <td><a href="https://github.com/zarzycki/cymep#cymep-cyclone-metrics-package">CyMeP README</a></td>
   </tr>
   <tr>
     <td>Drought Metrics</td>
     <td>Mean precipitation, mean SPI6, Mean SPI36, Seasonality of  Precipitation, Long term monthly mean, Fractional area coverage of drought, Proportion of dry months, Count of dry months, Drought intensity, Probability of drought initiation, probability of drought termination, overall score</td>
-    <td><a href="https://github.com/cmecmetrics/Drought_Metrics">Drought Metrics repository</a></td>
+    <td><a href="https://github.com/cmecmetrics/Drought_Metrics">Github repository</a></td>
     <td><a href="https://github.com/cmecmetrics/Drought_Metrics#drought_metrics">Drought Metrics README</a></td>
   </tr>
   <tr>
     <td>International Land Model Benchmarking (ILAMB)</td>
-    <td>Diagnostics figures: contour maps, time series plots, Taylor Diagrams
-    <br>Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
-    <br>Metrics categories: Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).</td>
-    <td><a href="https://github.com/rubisco-sfa/ILAMB">ILAMB repository</a></td>
-    <td><a href="https://www.ilamb.org/doc/">ILAMB documentation</a></td>
+    <td><b>Diagnostics figures</b>: contour maps, time series plots, Taylor Diagrams
+    <br><b>Metrics</b>: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <br>Metrics categories include Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).</td>
+    <td><a href="https://github.com/rubisco-sfa/ILAMB">Github repository</a></td>
+    <td><a href="https://www.ilamb.org/doc/">Documentation website</a></td>
   </tr>
   <tr>
     <td>International Ocean Model Benchmarking (IOMB)</td>
-    <td>Diagnostics figures: contour maps, time series plots, Taylor Diagrams
-    <br>Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
-    <br>Metrics categories: Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.</td>
-    <td><a href="https://github.com/rubisco-sfa/ILAMB">IOMB repository</a> (shared with ILAMB)</td>
-    <td><a href="https://www.ilamb.org/doc/">IOMB documentation</a> (shared with ILAMB)</td>
+    <td><b>Diagnostics figures</b>: contour maps, time series plots, Taylor Diagrams
+    <br><b>Metrics</b>: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <br>Metrics categories include Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.</td>
+    <td><a href="https://github.com/rubisco-sfa/ILAMB">Github repository</a> (shared with ILAMB)</td>
+    <td><a href="https://www.ilamb.org/doc/">Documentation website</a> (shared with ILAMB)</td>
   </tr>
   <tr>
     <td>Model Diagnostics Task Force (MDTF) Diagnostics</td>
-    <td>PODs: ENSO_MSE, ENSO_RWS, Extratropical Variance, Madden-Julian Oscillation Propogation and Amplitude, Madden-Julian Oscillation Spectra and Phasing, Madden-Julian Oscillation Teleconnections, Coupling between Soil Moisture and Evapotranspiration, Wavenumber-Frequency Spectra, Convective Transition Diagnostics, Mixed Layer Depth, Ocean Sufrace Latent Heat Flux Diagnostic, Diurnal Cycle of Precipitation, Surface Temperature Extremes and Distribution Shape, Tropical Pacific Sea Level Diagnostic</td>
-    <td><a href="https://github.com/NOAA-GFDL/MDTF-diagnostics">MDTF Diagnostics repository</a></td>
-    <td><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/">MDTF Diagnostics documentation</a></td>
+    <td><b>Process Oriented Diagnostics (PODs)</b>: ENSO_MSE, ENSO_RWS, Extratropical Variance, Madden-Julian Oscillation Propogation and Amplitude, Madden-Julian Oscillation Spectra and Phasing, Madden-Julian Oscillation Teleconnections, Coupling between Soil Moisture and Evapotranspiration, Wavenumber-Frequency Spectra, Convective Transition Diagnostics, Mixed Layer Depth, Ocean Sufrace Latent Heat Flux Diagnostic, Diurnal Cycle of Precipitation, Surface Temperature Extremes and Distribution Shape, Tropical Pacific Sea Level Diagnostic</td>
+    <td><a href="https://github.com/NOAA-GFDL/MDTF-diagnostics">Github repository</a></td>
+    <td><a href="https://mdtf-diagnostics.readthedocs.io/en/latest/">Documentation website</a></td>
   </tr>
   <tr>
     <td>PCMDI Metrics Package (PMP)</td>
@@ -70,7 +70,7 @@ Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actu
     <br><b>ENSO_tel</b>: EnsoAmpl, EnsoPrMapDjfCorr, EnsoPrMapDjfRmse, EnsoPrMapDjfStd, EnsoPrMapJjaCorr, EnsoPrMapJjaRmse, EnsoPrMapJjaStd, EnsoSeasonality, EnsoSstLonRmse, EnsoSstMapDjfCorr, EnsoSstMapDjfRmse, EnsoSstMapDjfStd, EnsoSstMapJjaCorr, EnsoSstMapJjaRmse, EnsoSstMapJjaStd
     <br><b>ENSO_proc</b>: BiasSstLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoFbSstTaux, EnsoFbSstThf, EnsoSeasonality, EnsoSstLonRmse, EnsoSstSkew, EnsodSstOce_2
     <br><b>Precipitation variability</b>: Forced annual, forced semi-annual, unforced interannual, unforced seasonal-annual, unforced sub-seasonal, unforced synoptic</td>
-    <td><a href="https://github.com/PCMDI/pcmdi_metrics">PCMDI metrics repository</a></td>
-    <td><a href="https://pcmdi.github.io/pcmdi_metrics/">PCMDI Metrics documentation</a></td>
+    <td><a href="https://github.com/PCMDI/pcmdi_metrics">Github repository</a></td>
+    <td><a href="https://pcmdi.github.io/pcmdi_metrics/">Documentation website</a></td>
 </tr>
 </table> 

--- a/metrics.md
+++ b/metrics.md
@@ -23,31 +23,32 @@ This table describes the metrics available in CMEC packages
   </tr>
   <tr>
     <td>Cyclone Metrics Package (CyMeP)</td>
-    <td><b>Storm characteristics</b>: tropical cyclone days, storm genesis, storm intensity (minimum sea level pressure, maximum 10-meter wind speed, accumulated cyclone energy,  pressure accumulated cyclone energy), latitude of lifetime-maximum intensity
-    <br><b>Statistics</b>: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
+    <td><b>Statistics</b>: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
+    <br>Statistics measure the following storm characteristics: tropical cyclone days, storm genesis, storm intensity (minimum sea level pressure, maximum 10-meter wind speed, accumulated cyclone energy,  pressure accumulated cyclone energy), latitude of lifetime-maximum intensity
     <br><b>Figures</b>: Scorecards, Spatial density maps, taylor diagrams, interannual cycle line plots, seasonal cycle line plots</td>
     <td><a href="https://github.com/zarzycki/cymep">Github repository</a></td>
     <td><a href="https://github.com/zarzycki/cymep#cymep-cyclone-metrics-package">CyMeP README</a></td>
   </tr>
   <tr>
     <td>Drought Metrics</td>
-    <td>Mean precipitation, mean SPI6, Mean SPI36, Seasonality of  Precipitation, Long term monthly mean, Fractional area coverage of drought, Proportion of dry months, Count of dry months, Drought intensity, Probability of drought initiation, probability of drought termination, overall score</td>
+    <td><b>Metrics</b>: Mean precipitation, mean SPI6, Mean SPI36, Seasonality of  Precipitation, Long term monthly mean, Fractional area coverage of drought, Proportion of dry months, Count of dry months, Drought intensity, Probability of drought initiation, Probability of drought termination, Overall score
+    <br><b>Figures</b>: Taylor diagram, heatmap</td>
     <td><a href="https://github.com/cmecmetrics/Drought_Metrics">Github repository</a></td>
     <td><a href="https://github.com/cmecmetrics/Drought_Metrics#drought_metrics">Drought Metrics README</a></td>
   </tr>
   <tr>
     <td>International Land Model Benchmarking (ILAMB)</td>
-    <td><b>Diagnostics figures</b>: contour maps, time series plots, Taylor Diagrams
-    <br><b>Metrics</b>: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
-    <br>Metrics categories include Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).</td>
+    <td><b>Metrics</b>: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <br>Metrics categories include Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).
+    <br><b>Figures</b>: contour maps, time series plots, Taylor Diagrams</td>
     <td><a href="https://github.com/rubisco-sfa/ILAMB">Github repository</a></td>
     <td><a href="https://www.ilamb.org/doc/">Documentation website</a></td>
   </tr>
   <tr>
     <td>International Ocean Model Benchmarking (IOMB)</td>
-    <td><b>Diagnostics figures</b>: contour maps, time series plots, Taylor Diagrams
-    <br><b>Metrics</b>: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
-    <br>Metrics categories include Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.</td>
+    <td><b>Metrics</b>: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    <br>Metrics categories include Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.
+    <br><b>Figures</b>: contour maps, time series plots, Taylor Diagrams</td>
     <td><a href="https://github.com/rubisco-sfa/ILAMB">Github repository</a> (shared with ILAMB)</td>
     <td><a href="https://www.ilamb.org/doc/">Documentation website</a> (shared with ILAMB)</td>
   </tr>

--- a/metrics.md
+++ b/metrics.md
@@ -18,17 +18,15 @@
     <td>Analyzing Scales of Precipitation (ASoP)</td>
     <td>Coherence: Temporal intermittency, Spatial intermittency
   Coherence figures: correlations of precipitation in space and time over regional blocks.
-Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actual and fractional contribution to precipitation rate by intensity range, 
-</td>
-    <td><a href="https://github.com/nick-klingaman/ASoP">ASoP repository</a>a></td>
+Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actual and fractional contribution to precipitation rate by intensity range</td>
+    <td><a href="https://github.com/nick-klingaman/ASoP">ASoP repository</a></td>
     <td><a href="https://github.com/nick-klingaman/ASoP/blob/master/ASoP_guide.pdf">User Guide</a></td>
   </tr>
   <tr>
     <td>Cyclone Metrics Package (CyMeP)</td>
     <td> Storm characteristics: tropical cyclone days, storm genesis, storm intensity (minimum sea level pressure, maximum 10-meter wind speed, accumulated cyclone energy,  pressure accumulated cyclone energy), latitude of lifetime-maximum intensity
-    <b>Statistics: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
-    <b>Figures: Scorecards, Spatial density maps, taylor diagrams, interannual cycle line plots, seasonal cycle line plots
-    </td>
+    Statistics: mean, bias, Pearson product-moment coefficient of linear correlation, Spearman rank correlation, hit rate, false alarm ratio
+    Figures: Scorecards, Spatial density maps, taylor diagrams, interannual cycle line plots, seasonal cycle line plots</td>
     <td><a href="https://github.com/zarzycki/cymep">CyMeP repository</a></td>
     <td><a href="https://github.com/zarzycki/cymep#cymep-cyclone-metrics-package">CyMeP README</a></td>
   </tr>
@@ -41,18 +39,16 @@ Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actu
   <tr>
     <td>International Land Model Benchmarking (ILAMB)</td>
     <td>Diagnostics figures: contour maps, time series plots, Taylor Diagrams
-    <b>Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
-    <b>Metrics categories: Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).
-</td>
+    Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    Metrics categories: Ecosystem and Carbon Cycle, Hydrology Cycle, Radiation and Energy Cycle, Forcings, and Relationships (Gross Primary Productivity, Leaf area index, and Evapotranspiration).</td>
     <td><a href="https://github.com/rubisco-sfa/ILAMB">ILAMB repository</a></td>
     <td><a href="https://www.ilamb.org/doc/">ILAMB documentation</a></td>
   </tr>
   <tr>
     <td>International Ocean Model Benchmarking (IOMB)</td>
     <td>Diagnostics figures: contour maps, time series plots, Taylor Diagrams
-    <b>Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
-    <b>Metrics categories: Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.
-</td>
+    Metrics: An overall score that accounts for spatial and temporal statistics of a model compared with observations for different quantities.
+    Metrics categories: Ecosystems, Nutrients, Carbon, Physical Drivers, and Relationships.</td>
     <td><a href="https://github.com/rubisco-sfa/ILAMB">IOMB repository</a> (shared with ILAMB)</td>
     <td><a href="https://www.ilamb.org/doc/">IOMB documentation</a> (shared with ILAMB)</td>
   </tr>
@@ -65,17 +61,16 @@ Spectral: histogram overlap metric, 1d histograms of precipitation, Maps of actu
   <tr>
     <td>PCMDI Metrics Package (PMP)</td>
     <td>Mean Climate: bias_xy, cor_xy, mae_xy, mean-obs_xy, mean_xy, rms_devzm, rms_xy, rms_xyt, rms_y, rmsc_xy, std-obs_xy, std-obs_xyt, std_xy, std_xy_devzm, std_xyt
-    <b>Monsoon (Wang): correlation, rmsn, threat score
-    <b>Monsoon (Sperber): decay index, duration, onset index, slope
-    <b>Diurnal Cycle: harmonic 1, 2, and 3: amp_avg_lnd, pha_avg_lnd, amp_avg_ocn, pha_avg_ocn
-    <b>Modes of Variability: bias, bias_glo, cor, cor_glo, frac, frac_cbf_regrid, mean, mean_glo, rms, rms_glo, rmsc, rmsc_glo, stdv_pc, std_pc_ratio_to_obs, tcor_cbf_vs_eof_pc
-    <b>MJO metrics: east power, west power, East-west power ratio
-    <b>ENSO_perf: BiasPrLatRmse, BiasPrLonRmse, BiasSSTLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoDuration, EnsoSeasonality, EnsoSstDiversity_2, EnsoSSTLonRmse, EnsoSstSkew, EnsoSstTsRmse, SeasonalPrLatRmse, SeasonalPrLonRmse, SeasonalSstLonRmse, SeasonalTauxLonRmse
-    <b>ENSO_tel: EnsoAmpl, EnsoPrMapDjfCorr, EnsoPrMapDjfRmse, EnsoPrMapDjfStd, EnsoPrMapJjaCorr, EnsoPrMapJjaRmse, EnsoPrMapJjaStd, EnsoSeasonality, EnsoSstLonRmse, EnsoSstMapDjfCorr, EnsoSstMapDjfRmse, EnsoSstMapDjfStd, EnsoSstMapJjaCorr, EnsoSstMapJjaRmse, EnsoSstMapJjaStd
-    <b>ENSO_proc: BiasSstLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoFbSstTaux, EnsoFbSstThf, EnsoSeasonality, EnsoSstLonRmse, EnsoSstSkew, EnsodSstOce_2
-    <b>Precipitation variability: Forced annual, forced semi-annual, unforced interannual, unforced seasonal-annual, unforced sub-seasonal, unforced synoptic
-    </td>
+    Monsoon (Wang): correlation, rmsn, threat score
+    Monsoon (Sperber): decay index, duration, onset index, slope
+    Diurnal Cycle: harmonic 1, 2, and 3: amp_avg_lnd, pha_avg_lnd, amp_avg_ocn, pha_avg_ocn
+    Modes of Variability: bias, bias_glo, cor, cor_glo, frac, frac_cbf_regrid, mean, mean_glo, rms, rms_glo, rmsc, rmsc_glo, stdv_pc, std_pc_ratio_to_obs, tcor_cbf_vs_eof_pc
+    MJO metrics: east power, west power, East-west power ratio
+    ENSO_perf: BiasPrLatRmse, BiasPrLonRmse, BiasSSTLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoDuration, EnsoSeasonality, EnsoSstDiversity_2, EnsoSSTLonRmse, EnsoSstSkew, EnsoSstTsRmse, SeasonalPrLatRmse, SeasonalPrLonRmse, SeasonalSstLonRmse, SeasonalTauxLonRmse
+    ENSO_tel: EnsoAmpl, EnsoPrMapDjfCorr, EnsoPrMapDjfRmse, EnsoPrMapDjfStd, EnsoPrMapJjaCorr, EnsoPrMapJjaRmse, EnsoPrMapJjaStd, EnsoSeasonality, EnsoSstLonRmse, EnsoSstMapDjfCorr, EnsoSstMapDjfRmse, EnsoSstMapDjfStd, EnsoSstMapJjaCorr, EnsoSstMapJjaRmse, EnsoSstMapJjaStd
+    ENSO_proc: BiasSstLonRmse, BiasTauxLonRmse, EnsoAmpl, EnsoFbSstTaux, EnsoFbSstThf, EnsoSeasonality, EnsoSstLonRmse, EnsoSstSkew, EnsodSstOce_2
+    Precipitation variability: Forced annual, forced semi-annual, unforced interannual, unforced seasonal-annual, unforced sub-seasonal, unforced synoptic</td>
     <td><a href="https://github.com/PCMDI/pcmdi_metrics">PCMDI metrics repository</a></td>
     <td><a href="https://pcmdi.github.io/pcmdi_metrics/">PCMDI Metrics documentation</a></td>
-  </tr>
+</tr>
 </table> 


### PR DESCRIPTION
I've added a new page under the "Capabilities" dropdown that contains a table of Model Evaluation Packages. Each row contains information about a CMEC module. I've also added a little more information about community contributed packages to the Capabilities page.