### PR TITLE
google analytics for CMEC

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,4 +9,13 @@
     <a href="https://github.com/PCMDI/CMEC">GitHub</a> </br>
     Learn about the Department of Energy’s <a href="https://doe.responsibledisclosure.com/hc/en-us">Vulnerability Disclosure Program</a>
   </p>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-X0NPWZYG8E"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-X0NPWZYG8E');
+  </script>
 </footer>


### PR DESCRIPTION
Add google analytics dedicated for CMEC website in separate, in addition to that for PCMDI overall (that was added by @durack1 via https://github.com/PCMDI/CMEC/pull/113)